### PR TITLE
Create Python client for LED matrix scoreboard

### DIFF
--- a/client-python/.env.example
+++ b/client-python/.env.example
@@ -1,0 +1,21 @@
+# OSM Device Adapter Scoreboard Configuration
+
+# API Configuration
+API_BASE_URL=https://your-server.example.com
+CLIENT_ID=scoreboard-rpi
+
+# Display Configuration
+# Set to "true" to run without actual LED matrix hardware (for development/testing)
+SIMULATE_DISPLAY=false
+
+# Update Interval
+# How often to poll for new scores (in seconds)
+POLL_INTERVAL=30
+
+# Token Storage
+# Where to save the OAuth access token
+TOKEN_FILE=/var/lib/scoreboard/token.txt
+
+# Logging
+# Options: DEBUG, INFO, WARNING, ERROR
+LOG_LEVEL=INFO

--- a/client-python/.gitignore
+++ b/client-python/.gitignore
@@ -1,0 +1,30 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+env/
+venv/
+ENV/
+*.egg-info/
+dist/
+build/
+
+# Environment and configuration
+.env
+*.log
+
+# Token storage
+token.txt
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db

--- a/client-python/README.md
+++ b/client-python/README.md
@@ -1,0 +1,302 @@
+# LED Matrix Scoreboard Client
+
+Python client for displaying scout patrol scores on a 64x32 LED matrix using the Adafruit RGB Matrix HAT on Raspberry Pi.
+
+## Hardware Requirements
+
+- Raspberry Pi (tested on Pi 3/4)
+- [Adafruit RGB Matrix HAT](https://www.adafruit.com/product/2345)
+- 64x32 RGB LED Matrix Panel
+- 5V 4A power supply for the LED matrix
+
+## Features
+
+- **OAuth Device Flow Authentication** - Displays user code on the matrix for easy authorization
+- **Automatic Score Updates** - Polls for patrol scores at configurable intervals
+- **Headless Operation** - All user interaction happens on the LED display
+- **Error Handling** - Displays errors on the matrix for easy troubleshooting
+- **Token Persistence** - Saves authentication token to survive reboots
+- **Auto-start** - Can run as a systemd service
+
+## Installation
+
+### 1. Install System Dependencies
+
+```bash
+# Update system
+sudo apt update
+sudo apt upgrade -y
+
+# Install required packages
+sudo apt install -y python3 python3-pip python3-dev git
+
+# Install build tools for RGB matrix library
+sudo apt install -y build-essential libgraphicsmagick++-dev \
+    libwebp-dev libjpeg-dev
+```
+
+### 2. Install RGB Matrix Library
+
+The Adafruit RGB Matrix library must be compiled from source:
+
+```bash
+# Clone the library
+cd ~
+git clone https://github.com/hzeller/rpi-rgb-led-matrix.git
+cd rpi-rgb-led-matrix
+
+# Build the library
+make
+
+# Install Python bindings
+cd bindings/python
+sudo pip3 install -e .
+```
+
+### 3. Install Scoreboard Application
+
+```bash
+# Clone this repository (or copy the client-python directory)
+cd ~
+git clone <repository-url>
+cd OsmDeviceAdapter/client-python
+
+# Install Python dependencies
+pip3 install -r requirements.txt
+
+# Make the main script executable
+chmod +x src/scoreboard.py
+```
+
+### 4. Configure the Application
+
+```bash
+# Copy example configuration
+cp .env.example .env
+
+# Edit configuration
+nano .env
+```
+
+Update these required settings in `.env`:
+- `API_BASE_URL`: URL of your OSM Device Adapter server
+- `CLIENT_ID`: Unique identifier for this scoreboard
+
+### 5. Test the Application
+
+Run in simulation mode first (no hardware required):
+
+```bash
+cd src
+SIMULATE_DISPLAY=true python3 scoreboard.py
+```
+
+You should see the device code in the terminal. Visit the verification URL and enter the code to complete authentication.
+
+### 6. Run on Real Hardware
+
+```bash
+# Run with hardware
+cd src
+python3 scoreboard.py
+```
+
+The user code will appear on the LED matrix. Visit the URL shown and enter the code.
+
+## Running as a Service
+
+To run the scoreboard automatically at boot:
+
+### 1. Install Service File
+
+```bash
+# Copy service file
+sudo cp systemd/scoreboard.service /etc/systemd/system/
+
+# Edit service file to match your paths
+sudo nano /etc/systemd/system/scoreboard.service
+```
+
+### 2. Create Token Directory
+
+```bash
+# Create directory for token storage
+sudo mkdir -p /var/lib/scoreboard
+sudo chown pi:pi /var/lib/scoreboard
+```
+
+### 3. Enable and Start Service
+
+```bash
+# Reload systemd
+sudo systemctl daemon-reload
+
+# Enable service to start at boot
+sudo systemctl enable scoreboard.service
+
+# Start service now
+sudo systemctl start scoreboard.service
+
+# Check status
+sudo systemctl status scoreboard.service
+```
+
+### 4. View Logs
+
+```bash
+# Follow logs in real-time
+sudo journalctl -u scoreboard.service -f
+
+# View recent logs
+sudo journalctl -u scoreboard.service -n 50
+```
+
+## Configuration Options
+
+All configuration is done via environment variables (or `.env` file):
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `API_BASE_URL` | `http://localhost:8080` | OSM Device Adapter server URL |
+| `CLIENT_ID` | `scoreboard-rpi` | Unique client identifier |
+| `POLL_INTERVAL` | `30` | Seconds between score updates |
+| `TOKEN_FILE` | `/var/lib/scoreboard/token.txt` | Where to save OAuth token |
+| `SIMULATE_DISPLAY` | `false` | Run without LED hardware |
+| `LOG_LEVEL` | `INFO` | Logging level (DEBUG, INFO, WARNING, ERROR) |
+
+## Display Layout
+
+The 64x32 matrix displays up to 4 patrols:
+
+```
+Eagles            145
+----------------------------
+Hawks             132
+----------------------------
+Wolves            128
+----------------------------
+Bears             115
+```
+
+- Patrol names: Left justified (truncated to 8 characters if longer)
+- Scores: Right justified
+- Separator lines between patrols
+
+## Troubleshooting
+
+### "rgbmatrix library not available"
+
+The RGB matrix library must be compiled and installed separately. See step 2 of Installation.
+
+### Display is flickering
+
+Adjust the `gpio_slowdown` parameter in `src/display.py`:
+
+```python
+options.gpio_slowdown = 4  # Increase if flickering (default: 2)
+```
+
+### Permission denied on GPIO
+
+Run with sudo or add your user to the gpio group:
+
+```bash
+sudo usermod -a -G gpio pi
+```
+
+Then reboot.
+
+### "Authentication expired"
+
+The saved token may have expired. Delete it and re-authenticate:
+
+```bash
+rm /var/lib/scoreboard/token.txt
+sudo systemctl restart scoreboard.service
+```
+
+Watch the matrix for the new device code.
+
+### Can't connect to API server
+
+1. Check `API_BASE_URL` in your `.env` file
+2. Verify network connectivity: `ping your-server.example.com`
+3. Check firewall rules
+4. View logs: `sudo journalctl -u scoreboard.service -n 50`
+
+### Display shows "Score Error"
+
+Check the logs for details:
+
+```bash
+sudo journalctl -u scoreboard.service -n 50
+```
+
+Common causes:
+- Network connectivity issues
+- Server is down
+- Authentication token expired
+
+## Development
+
+### Testing Without Hardware
+
+Set `SIMULATE_DISPLAY=true` to run without the LED matrix:
+
+```bash
+cd src
+SIMULATE_DISPLAY=true python3 scoreboard.py
+```
+
+Output will be printed to the terminal instead.
+
+### Project Structure
+
+```
+client-python/
+├── src/
+│   ├── scoreboard.py      # Main application
+│   ├── api_client.py      # OSM Device Adapter API client
+│   └── display.py         # LED matrix display wrapper
+├── systemd/
+│   └── scoreboard.service # Systemd service file
+├── requirements.txt       # Python dependencies
+├── .env.example          # Example configuration
+└── README.md             # This file
+```
+
+## Hardware Setup Notes
+
+### Wiring
+
+The Adafruit RGB Matrix HAT sits directly on the Raspberry Pi GPIO header. No wiring needed.
+
+Connect the LED matrix panel to the HAT's HUB75 connector.
+
+### Power
+
+**Important:** Power the LED matrix from its own 5V power supply, not from the Raspberry Pi.
+
+The Pi can be powered from the HAT's power input or separately via USB.
+
+### Performance
+
+For best performance:
+- Use Raspberry Pi 3 or newer
+- Disable audio and bluetooth in `/boot/config.txt`:
+  ```
+  dtparam=audio=off
+  dtoverlay=disable-bt
+  ```
+- Run in console mode (not desktop environment)
+
+## License
+
+See main repository LICENSE file.
+
+## Support
+
+For issues specific to:
+- This client: Open an issue in the repository
+- RGB Matrix library: See [rpi-rgb-led-matrix](https://github.com/hzeller/rpi-rgb-led-matrix)
+- Hardware setup: See [Adafruit's guide](https://learn.adafruit.com/adafruit-rgb-matrix-plus-real-time-clock-hat-for-raspberry-pi)

--- a/client-python/install.sh
+++ b/client-python/install.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# Installation script for LED Matrix Scoreboard
+
+set -e
+
+echo "================================="
+echo "LED Matrix Scoreboard Installer"
+echo "================================="
+echo
+
+# Check if running on Raspberry Pi
+if ! grep -q "Raspberry Pi" /proc/cpuinfo 2>/dev/null; then
+    echo "WARNING: This doesn't appear to be a Raspberry Pi"
+    echo "The RGB matrix library may not work correctly."
+    read -p "Continue anyway? (y/N) " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        exit 1
+    fi
+fi
+
+# Install system dependencies
+echo "Installing system dependencies..."
+sudo apt update
+sudo apt install -y python3 python3-pip python3-dev git \
+    build-essential libgraphicsmagick++-dev libwebp-dev libjpeg-dev
+
+# Install RGB Matrix library
+echo
+echo "Installing RGB Matrix library..."
+if [ ! -d ~/rpi-rgb-led-matrix ]; then
+    cd ~
+    git clone https://github.com/hzeller/rpi-rgb-led-matrix.git
+    cd rpi-rgb-led-matrix
+    make
+    cd bindings/python
+    sudo pip3 install -e .
+    echo "RGB Matrix library installed"
+else
+    echo "RGB Matrix library already exists, skipping..."
+fi
+
+# Install Python dependencies
+echo
+echo "Installing Python dependencies..."
+cd "$(dirname "$0")"
+pip3 install -r requirements.txt
+
+# Create configuration file
+echo
+if [ ! -f .env ]; then
+    echo "Creating configuration file..."
+    cp .env.example .env
+    echo "Configuration file created at .env"
+    echo "IMPORTANT: Edit .env and set your API_BASE_URL"
+else
+    echo "Configuration file already exists, skipping..."
+fi
+
+# Create token directory
+echo
+echo "Creating token storage directory..."
+sudo mkdir -p /var/lib/scoreboard
+sudo chown $USER:$USER /var/lib/scoreboard
+echo "Token directory created"
+
+# Make scripts executable
+echo
+echo "Setting permissions..."
+chmod +x src/scoreboard.py
+
+# Test installation
+echo
+echo "Testing installation..."
+if python3 -c "import requests" 2>/dev/null; then
+    echo "✓ Python dependencies OK"
+else
+    echo "✗ Python dependencies failed"
+    exit 1
+fi
+
+echo
+echo "================================="
+echo "Installation complete!"
+echo "================================="
+echo
+echo "Next steps:"
+echo "1. Edit .env and set your API_BASE_URL"
+echo "2. Test in simulation mode:"
+echo "   cd src && SIMULATE_DISPLAY=true python3 scoreboard.py"
+echo "3. Install as a service (optional):"
+echo "   sudo cp systemd/scoreboard.service /etc/systemd/system/"
+echo "   sudo nano /etc/systemd/system/scoreboard.service  # Edit paths"
+echo "   sudo systemctl daemon-reload"
+echo "   sudo systemctl enable scoreboard.service"
+echo "   sudo systemctl start scoreboard.service"
+echo

--- a/client-python/requirements.txt
+++ b/client-python/requirements.txt
@@ -1,0 +1,8 @@
+# Python dependencies for LED Matrix Scoreboard
+
+# HTTP client for API communication
+requests>=2.31.0
+
+# Note: The RGB Matrix library must be installed separately on Raspberry Pi
+# Installation instructions in README.md
+# On development machines, the app will run in simulation mode without it

--- a/client-python/src/api_client.py
+++ b/client-python/src/api_client.py
@@ -1,0 +1,271 @@
+"""API Client for OSM Device Adapter
+
+Handles device flow authentication and score polling.
+"""
+
+import time
+import requests
+from typing import Dict, List, Optional, Tuple
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass
+class DeviceAuthResponse:
+    """Response from device authorization request."""
+    device_code: str
+    user_code: str
+    verification_uri: str
+    verification_uri_complete: str
+    expires_in: int
+    interval: int
+
+
+@dataclass
+class TokenResponse:
+    """Response from token request."""
+    access_token: str
+    token_type: str
+    expires_in: int
+    refresh_token: Optional[str] = None
+
+
+@dataclass
+class PatrolScore:
+    """Represents a patrol and its score."""
+    id: str
+    name: str
+    score: int
+
+
+class DeviceFlowError(Exception):
+    """Base exception for device flow errors."""
+    pass
+
+
+class AuthorizationPending(DeviceFlowError):
+    """Authorization is still pending."""
+    pass
+
+
+class AccessDenied(DeviceFlowError):
+    """User denied the authorization."""
+    pass
+
+
+class ExpiredToken(DeviceFlowError):
+    """Device code has expired."""
+    pass
+
+
+class OSMDeviceClient:
+    """Client for OSM Device Adapter API."""
+
+    def __init__(self, base_url: str, client_id: str, timeout: int = 10):
+        """Initialize the API client.
+
+        Args:
+            base_url: Base URL of the OSM Device Adapter (e.g., "https://example.com")
+            client_id: Unique client identifier for this device
+            timeout: Request timeout in seconds
+        """
+        self.base_url = base_url.rstrip('/')
+        self.client_id = client_id
+        self.timeout = timeout
+        self.session = requests.Session()
+        self.access_token: Optional[str] = None
+
+    def request_device_code(self, scope: str = "section:member:read") -> DeviceAuthResponse:
+        """Request a device code to start the authorization flow.
+
+        Args:
+            scope: OAuth scope to request
+
+        Returns:
+            DeviceAuthResponse with device_code, user_code, etc.
+
+        Raises:
+            DeviceFlowError: If request fails
+        """
+        url = f"{self.base_url}/device/authorize"
+        payload = {
+            "client_id": self.client_id,
+            "scope": scope
+        }
+
+        try:
+            response = self.session.post(url, json=payload, timeout=self.timeout)
+            response.raise_for_status()
+            data = response.json()
+
+            return DeviceAuthResponse(
+                device_code=data["device_code"],
+                user_code=data["user_code"],
+                verification_uri=data["verification_uri"],
+                verification_uri_complete=data["verification_uri_complete"],
+                expires_in=data["expires_in"],
+                interval=data["interval"]
+            )
+        except requests.exceptions.RequestException as e:
+            raise DeviceFlowError(f"Failed to request device code: {e}")
+
+    def poll_for_token(self, device_code: str) -> TokenResponse:
+        """Poll for an access token.
+
+        Args:
+            device_code: Device code from request_device_code()
+
+        Returns:
+            TokenResponse with access_token
+
+        Raises:
+            AuthorizationPending: User hasn't authorized yet
+            AccessDenied: User denied authorization
+            ExpiredToken: Device code expired
+            DeviceFlowError: Other errors
+        """
+        url = f"{self.base_url}/device/token"
+        payload = {
+            "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+            "device_code": device_code,
+            "client_id": self.client_id
+        }
+
+        try:
+            response = self.session.post(url, json=payload, timeout=self.timeout)
+
+            # Check for pending authorization
+            if response.status_code == 400:
+                error_data = response.json()
+                error = error_data.get("error", "")
+
+                if error == "authorization_pending":
+                    raise AuthorizationPending("Authorization pending")
+                elif error == "access_denied":
+                    raise AccessDenied("User denied authorization")
+                elif error == "expired_token":
+                    raise ExpiredToken("Device code expired")
+                else:
+                    raise DeviceFlowError(f"Token error: {error}")
+
+            response.raise_for_status()
+            data = response.json()
+
+            return TokenResponse(
+                access_token=data["access_token"],
+                token_type=data["token_type"],
+                expires_in=data["expires_in"],
+                refresh_token=data.get("refresh_token")
+            )
+
+        except requests.exceptions.RequestException as e:
+            if not isinstance(e, DeviceFlowError):
+                raise DeviceFlowError(f"Failed to poll for token: {e}")
+            raise
+
+    def get_patrol_scores(self) -> Tuple[List[PatrolScore], datetime, datetime]:
+        """Get current patrol scores.
+
+        Returns:
+            Tuple of (patrol_scores, cached_at, expires_at)
+
+        Raises:
+            DeviceFlowError: If request fails or not authenticated
+        """
+        if not self.access_token:
+            raise DeviceFlowError("Not authenticated. Call authenticate() first.")
+
+        url = f"{self.base_url}/api/v1/patrols"
+        headers = {
+            "Authorization": f"Bearer {self.access_token}"
+        }
+
+        try:
+            response = self.session.get(url, headers=headers, timeout=self.timeout)
+            response.raise_for_status()
+            data = response.json()
+
+            patrols = [
+                PatrolScore(
+                    id=p["id"],
+                    name=p["name"],
+                    score=p["score"]
+                )
+                for p in data["patrols"]
+            ]
+
+            cached_at = datetime.fromisoformat(data["cached_at"].replace('Z', '+00:00'))
+            expires_at = datetime.fromisoformat(data["expires_at"].replace('Z', '+00:00'))
+
+            return patrols, cached_at, expires_at
+
+        except requests.exceptions.HTTPError as e:
+            if e.response.status_code == 401:
+                raise DeviceFlowError("Authentication expired or invalid")
+            raise DeviceFlowError(f"Failed to get patrol scores: {e}")
+        except requests.exceptions.RequestException as e:
+            raise DeviceFlowError(f"Failed to get patrol scores: {e}")
+
+    def authenticate(self, on_code_received=None, on_waiting=None) -> TokenResponse:
+        """Perform full device flow authentication.
+
+        Args:
+            on_code_received: Callback(user_code, verification_uri) when code is ready
+            on_waiting: Callback() called on each poll attempt
+
+        Returns:
+            TokenResponse with access_token
+
+        Raises:
+            DeviceFlowError: If authentication fails
+        """
+        # Step 1: Request device code
+        auth = self.request_device_code()
+
+        # Notify about the code
+        if on_code_received:
+            on_code_received(auth.user_code, auth.verification_uri)
+
+        # Step 2: Poll for token
+        start_time = time.time()
+        poll_interval = auth.interval
+
+        while True:
+            elapsed = time.time() - start_time
+            if elapsed > auth.expires_in:
+                raise ExpiredToken("Device code expired before authorization")
+
+            # Wait before polling
+            time.sleep(poll_interval)
+
+            if on_waiting:
+                on_waiting()
+
+            try:
+                token = self.poll_for_token(auth.device_code)
+                self.access_token = token.access_token
+                return token
+
+            except AuthorizationPending:
+                # Keep waiting
+                continue
+            except AccessDenied:
+                raise
+            except ExpiredToken:
+                raise
+
+    def is_authenticated(self) -> bool:
+        """Check if client has an access token.
+
+        Returns:
+            True if authenticated
+        """
+        return self.access_token is not None
+
+    def set_access_token(self, token: str):
+        """Set the access token manually.
+
+        Args:
+            token: Access token string
+        """
+        self.access_token = token

--- a/client-python/src/display.py
+++ b/client-python/src/display.py
@@ -1,0 +1,235 @@
+"""LED Matrix Display Module for Scoreboard
+
+Handles all LED matrix display operations for the 64x32 Adafruit RGB Matrix HAT.
+"""
+
+import time
+from typing import List, Tuple, Optional
+try:
+    from rgbmatrix import RGBMatrix, RGBMatrixOptions, graphics
+    MATRIX_AVAILABLE = True
+except ImportError:
+    MATRIX_AVAILABLE = False
+    print("WARNING: rgbmatrix library not available. Running in simulation mode.")
+
+
+class PatrolScore:
+    """Represents a patrol and its score."""
+    def __init__(self, name: str, score: int):
+        self.name = name
+        self.score = score
+
+
+class MatrixDisplay:
+    """Manages the LED matrix display for the scoreboard."""
+
+    def __init__(self, rows: int = 32, cols: int = 64, simulate: bool = False):
+        """Initialize the LED matrix.
+
+        Args:
+            rows: Number of LED rows (default: 32)
+            cols: Number of LED columns (default: 64)
+            simulate: If True, run in simulation mode without hardware
+        """
+        self.rows = rows
+        self.cols = cols
+        self.simulate = simulate or not MATRIX_AVAILABLE
+
+        if not self.simulate:
+            # Configure the matrix
+            options = RGBMatrixOptions()
+            options.rows = rows
+            options.cols = cols
+            options.chain_length = 1
+            options.parallel = 1
+            options.hardware_mapping = 'adafruit-hat'
+            options.gpio_slowdown = 2  # Adjust if flickering occurs
+            options.brightness = 60  # 0-100
+            options.pwm_lsb_nanoseconds = 130  # Lower values = higher refresh rate
+
+            self.matrix = RGBMatrix(options=options)
+            self.canvas = self.matrix.CreateFrameCanvas()
+
+            # Load fonts
+            self.font = graphics.Font()
+            self.font.LoadFont("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf")
+            self.small_font = graphics.Font()
+            self.small_font.LoadFont("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf")
+        else:
+            print(f"[DISPLAY] Simulation mode: {cols}x{rows} matrix")
+            self.matrix = None
+            self.canvas = None
+
+    def clear(self):
+        """Clear the display."""
+        if not self.simulate:
+            self.canvas.Clear()
+        else:
+            print("[DISPLAY] Clear")
+
+    def show(self):
+        """Update the display with current canvas content."""
+        if not self.simulate:
+            self.canvas = self.matrix.SwapOnVSync(self.canvas)
+
+    def draw_text(self, x: int, y: int, text: str,
+                  color: Tuple[int, int, int] = (255, 255, 255),
+                  font_size: str = "normal"):
+        """Draw text at specified position.
+
+        Args:
+            x: X coordinate (0 = left edge)
+            y: Y coordinate (baseline of text, not top)
+            text: Text to display
+            color: RGB tuple (0-255 each)
+            font_size: "normal" or "small"
+        """
+        if not self.simulate:
+            font = self.font if font_size == "normal" else self.small_font
+            text_color = graphics.Color(color[0], color[1], color[2])
+            graphics.DrawText(self.canvas, font, x, y, text_color, text)
+        else:
+            print(f"[DISPLAY] Text at ({x},{y}): '{text}' color={color}")
+
+    def draw_line(self, x1: int, y1: int, x2: int, y2: int,
+                  color: Tuple[int, int, int] = (100, 100, 100)):
+        """Draw a line between two points.
+
+        Args:
+            x1, y1: Start coordinates
+            x2, y2: End coordinates
+            color: RGB tuple
+        """
+        if not self.simulate:
+            line_color = graphics.Color(color[0], color[1], color[2])
+            graphics.DrawLine(self.canvas, x1, y1, x2, y2, line_color)
+        else:
+            print(f"[DISPLAY] Line from ({x1},{y1}) to ({x2},{y2})")
+
+    def show_device_code(self, code: str, url: str):
+        """Display the device authorization code.
+
+        Args:
+            code: User code to display (e.g., "ABCD-EFGH")
+            url: Verification URL
+        """
+        self.clear()
+
+        # Draw title
+        self.draw_text(2, 6, "Enter Code:", color=(0, 255, 255))
+
+        # Draw the code prominently
+        self.draw_text(4, 20, code, color=(255, 255, 0))
+
+        # Draw URL hint (may be truncated)
+        url_short = url.replace("https://", "").replace("http://", "")
+        if len(url_short) > 12:
+            url_short = url_short[:12] + "..."
+        self.draw_text(2, 30, url_short, color=(100, 100, 100))
+
+        self.show()
+
+        if self.simulate:
+            print(f"\n{'='*40}")
+            print(f"DEVICE CODE: {code}")
+            print(f"Visit: {url}")
+            print(f"{'='*40}\n")
+
+    def show_waiting(self, message: str = "Waiting..."):
+        """Display a waiting message.
+
+        Args:
+            message: Message to display
+        """
+        self.clear()
+        self.draw_text(2, 16, message, color=(255, 200, 0))
+        self.show()
+
+        if self.simulate:
+            print(f"[DISPLAY] {message}")
+
+    def show_error(self, error: str):
+        """Display an error message.
+
+        Args:
+            error: Error message to display
+        """
+        self.clear()
+
+        # Draw "ERROR" in red
+        self.draw_text(2, 8, "ERROR:", color=(255, 0, 0))
+
+        # Draw error message, truncated if needed
+        if len(error) > 11:
+            error = error[:11] + "..."
+        self.draw_text(2, 24, error, color=(255, 100, 100))
+
+        self.show()
+
+        if self.simulate:
+            print(f"[DISPLAY ERROR] {error}")
+
+    def show_scores(self, patrols: List[PatrolScore]):
+        """Display patrol names and scores.
+
+        Args:
+            patrols: List of PatrolScore objects (up to 4)
+        """
+        self.clear()
+
+        # Display up to 4 patrols
+        row_height = 8
+        for i, patrol in enumerate(patrols[:4]):
+            y = (i * row_height) + 7  # Baseline for text
+
+            # Draw patrol name (left justified)
+            name = patrol.name
+            if len(name) > 8:  # Truncate long names
+                name = name[:8]
+            self.draw_text(1, y, name, color=(0, 255, 0))
+
+            # Draw score (right justified)
+            score_text = str(patrol.score)
+            # Estimate text width (rough: 5 pixels per character)
+            score_width = len(score_text) * 5
+            score_x = self.cols - score_width - 1
+            self.draw_text(score_x, y, score_text, color=(255, 255, 0))
+
+            # Draw separator line between patrols
+            if i < len(patrols) - 1:
+                line_y = (i + 1) * row_height - 1
+                self.draw_line(0, line_y, self.cols - 1, line_y, color=(50, 50, 50))
+
+        self.show()
+
+        if self.simulate:
+            print("\n" + "="*40)
+            print("SCOREBOARD")
+            print("="*40)
+            for patrol in patrols[:4]:
+                print(f"{patrol.name:<20} {patrol.score:>10}")
+            print("="*40 + "\n")
+
+    def show_message(self, message: str, color: Tuple[int, int, int] = (255, 255, 255)):
+        """Display a centered message.
+
+        Args:
+            message: Message to display
+            color: RGB color tuple
+        """
+        self.clear()
+        # Rough centering (assumes ~5 pixels per character)
+        text_width = len(message) * 5
+        x = max(0, (self.cols - text_width) // 2)
+        y = self.rows // 2
+        self.draw_text(x, y, message, color=color)
+        self.show()
+
+        if self.simulate:
+            print(f"[DISPLAY] {message}")
+
+    def cleanup(self):
+        """Clean up resources."""
+        if not self.simulate and self.matrix:
+            self.clear()
+            self.show()

--- a/client-python/src/scoreboard.py
+++ b/client-python/src/scoreboard.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""LED Matrix Scoreboard Application
+
+Displays scout patrol scores on a 64x32 LED matrix using the Adafruit RGB Matrix HAT.
+Authenticates using OAuth device flow and polls for score updates.
+"""
+
+import os
+import sys
+import time
+import signal
+import logging
+from pathlib import Path
+from typing import Optional
+
+from api_client import OSMDeviceClient, DeviceFlowError, AccessDenied, ExpiredToken
+from display import MatrixDisplay, PatrolScore as DisplayPatrolScore
+
+
+# Configuration from environment variables
+API_BASE_URL = os.getenv("API_BASE_URL", "http://localhost:8080")
+CLIENT_ID = os.getenv("CLIENT_ID", "scoreboard-rpi")
+POLL_INTERVAL = int(os.getenv("POLL_INTERVAL", "30"))  # Seconds between score updates
+TOKEN_FILE = Path(os.getenv("TOKEN_FILE", "/var/lib/scoreboard/token.txt"))
+SIMULATE_DISPLAY = os.getenv("SIMULATE_DISPLAY", "false").lower() == "true"
+
+# Logging configuration
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
+logging.basicConfig(
+    level=LOG_LEVEL,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+
+class ScoreboardApp:
+    """Main scoreboard application."""
+
+    def __init__(self):
+        """Initialize the scoreboard application."""
+        self.display = MatrixDisplay(rows=32, cols=64, simulate=SIMULATE_DISPLAY)
+        self.client = OSMDeviceClient(base_url=API_BASE_URL, client_id=CLIENT_ID)
+        self.running = True
+        self.authenticated = False
+
+        # Set up signal handlers for graceful shutdown
+        signal.signal(signal.SIGINT, self._signal_handler)
+        signal.signal(signal.SIGTERM, self._signal_handler)
+
+    def _signal_handler(self, signum, frame):
+        """Handle shutdown signals."""
+        logger.info(f"Received signal {signum}, shutting down...")
+        self.running = False
+
+    def load_token(self) -> bool:
+        """Load saved access token from file.
+
+        Returns:
+            True if token was loaded successfully
+        """
+        try:
+            if TOKEN_FILE.exists():
+                token = TOKEN_FILE.read_text().strip()
+                if token:
+                    self.client.set_access_token(token)
+                    logger.info("Loaded saved access token")
+                    return True
+        except Exception as e:
+            logger.warning(f"Failed to load token: {e}")
+        return False
+
+    def save_token(self, token: str):
+        """Save access token to file.
+
+        Args:
+            token: Access token to save
+        """
+        try:
+            TOKEN_FILE.parent.mkdir(parents=True, exist_ok=True)
+            TOKEN_FILE.write_text(token)
+            TOKEN_FILE.chmod(0o600)  # Secure permissions
+            logger.info("Saved access token")
+        except Exception as e:
+            logger.error(f"Failed to save token: {e}")
+
+    def authenticate(self):
+        """Perform device flow authentication."""
+        logger.info("Starting device flow authentication...")
+
+        def on_code_received(user_code: str, verification_uri: str):
+            """Called when device code is received."""
+            logger.info(f"User code: {user_code}")
+            logger.info(f"Verification URI: {verification_uri}")
+            self.display.show_device_code(user_code, verification_uri)
+
+        def on_waiting():
+            """Called while waiting for authorization."""
+            logger.debug("Waiting for user authorization...")
+
+        try:
+            token = self.client.authenticate(
+                on_code_received=on_code_received,
+                on_waiting=on_waiting
+            )
+
+            logger.info("Authentication successful!")
+            self.save_token(token.access_token)
+            self.authenticated = True
+
+            # Show success message briefly
+            self.display.show_message("Authorized!", color=(0, 255, 0))
+            time.sleep(2)
+
+        except AccessDenied:
+            logger.error("User denied authorization")
+            self.display.show_error("Access Denied")
+            time.sleep(5)
+            raise
+
+        except ExpiredToken:
+            logger.error("Device code expired")
+            self.display.show_error("Code Expired")
+            time.sleep(5)
+            raise
+
+        except DeviceFlowError as e:
+            logger.error(f"Authentication failed: {e}")
+            self.display.show_error("Auth Failed")
+            time.sleep(5)
+            raise
+
+    def update_scores(self):
+        """Fetch and display current patrol scores."""
+        try:
+            patrols, cached_at, expires_at = self.client.get_patrol_scores()
+
+            logger.info(f"Received {len(patrols)} patrol scores (cached at {cached_at})")
+
+            # Convert to display format
+            display_patrols = [
+                DisplayPatrolScore(name=p.name, score=p.score)
+                for p in patrols
+            ]
+
+            # Update display
+            self.display.show_scores(display_patrols)
+
+        except DeviceFlowError as e:
+            logger.error(f"Failed to get patrol scores: {e}")
+            self.display.show_error("Score Error")
+
+            # If authentication error, mark as not authenticated
+            if "Authentication" in str(e) or "401" in str(e):
+                self.authenticated = False
+                logger.warning("Authentication appears invalid, will re-authenticate")
+
+    def run(self):
+        """Main application loop."""
+        logger.info("Scoreboard application starting...")
+        logger.info(f"API: {API_BASE_URL}")
+        logger.info(f"Client ID: {CLIENT_ID}")
+        logger.info(f"Poll interval: {POLL_INTERVAL}s")
+
+        try:
+            # Show startup message
+            self.display.show_message("Starting...")
+            time.sleep(1)
+
+            # Try to load saved token
+            if self.load_token():
+                # Verify token works by trying to get scores
+                try:
+                    self.update_scores()
+                    self.authenticated = True
+                    logger.info("Saved token is valid")
+                except DeviceFlowError:
+                    logger.warning("Saved token is invalid, will re-authenticate")
+                    self.authenticated = False
+
+            # Authenticate if needed
+            if not self.authenticated:
+                self.authenticate()
+
+            # Main loop: periodically update scores
+            last_update = 0
+            while self.running:
+                current_time = time.time()
+
+                # Update scores at specified interval
+                if current_time - last_update >= POLL_INTERVAL:
+                    # Re-authenticate if needed
+                    if not self.authenticated:
+                        self.authenticate()
+
+                    # Update scores
+                    self.update_scores()
+                    last_update = current_time
+
+                # Sleep briefly to avoid busy-waiting
+                time.sleep(1)
+
+        except KeyboardInterrupt:
+            logger.info("Interrupted by user")
+        except Exception as e:
+            logger.exception(f"Unexpected error: {e}")
+            self.display.show_error("Fatal Error")
+            time.sleep(5)
+        finally:
+            logger.info("Cleaning up...")
+            self.display.cleanup()
+            logger.info("Scoreboard application stopped")
+
+
+def main():
+    """Main entry point."""
+    app = ScoreboardApp()
+    app.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/client-python/systemd/scoreboard.service
+++ b/client-python/systemd/scoreboard.service
@@ -1,0 +1,37 @@
+[Unit]
+Description=LED Matrix Scoreboard for Scout Patrols
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=pi
+Group=pi
+WorkingDirectory=/home/pi/OsmDeviceAdapter/client-python/src
+
+# Environment variables (update these paths and values)
+Environment="API_BASE_URL=https://your-server.example.com"
+Environment="CLIENT_ID=scoreboard-rpi"
+Environment="POLL_INTERVAL=30"
+Environment="TOKEN_FILE=/var/lib/scoreboard/token.txt"
+Environment="LOG_LEVEL=INFO"
+Environment="SIMULATE_DISPLAY=false"
+
+# Run the scoreboard application
+ExecStart=/usr/bin/python3 /home/pi/OsmDeviceAdapter/client-python/src/scoreboard.py
+
+# Restart policy
+Restart=always
+RestartSec=10
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=scoreboard
+
+# Security settings
+NoNewPrivileges=true
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Implements a headless Python client for Raspberry Pi with Adafruit RGB Matrix HAT to display scout patrol scores on a 64x32 LED matrix.

Features:
- OAuth device flow authentication with code displayed on matrix
- Automatic polling and display of patrol scores
- Error handling and display on the LED matrix
- Token persistence across reboots
- Simulation mode for development without hardware
- Systemd service for auto-start
- Support for 4 patrols with names (left) and scores (right)

Components:
- display.py: LED matrix wrapper using rpi-rgb-led-matrix library
- api_client.py: OSM Device Adapter API client with device flow
- scoreboard.py: Main application orchestrating auth and display
- systemd service file and installation script

Hardware: Raspberry Pi + Adafruit RGB Matrix HAT + 64x32 LED panel