### PR TITLE
Refactor rate limiting store implementation

### DIFF
--- a/internal/db/metrics_store.go
+++ b/internal/db/metrics_store.go
@@ -2,13 +2,24 @@ package db
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"strconv"
 	"time"
+
+	"github.com/m0rjc/OsmDeviceAdapter/internal/osm"
+	"github.com/redis/go-redis/v9"
 )
 
 const (
-	osmServiceBlockedKey = "osm:blocked:service"
-	osmUserBlockedPrefix = "osm:blocked:user:"
+	osmServiceBlockedKey   = "osm:blocked:service"
+	osmUserBlockedPrefix   = "osm:blocked:user:"
+	osmUserRateLimitPrefix = "osm:ratelimit:user:"
+
+	// In-memory cache TTL for rate limit info (30 seconds)
+	rateLimitCacheTTL = 30 * time.Second
+	// Redis TTL for rate limit info (5 minutes)
+	rateLimitRedisTTL = 5 * time.Minute
 )
 
 // MarkOsmServiceBlocked marks the OSM service as blocked.
@@ -22,10 +33,19 @@ func (r *RedisClient) IsOsmServiceBlocked(ctx context.Context) bool {
 	return err == nil && val == "1"
 }
 
-// MarkUserTemporarilyBlocked marks a user as temporarily blocked.
-func (r *RedisClient) MarkUserTemporarilyBlocked(ctx context.Context, userId int, retryAfter time.Duration) {
+// MarkUserTemporarilyBlocked marks a user as temporarily blocked until the specified time.
+func (r *RedisClient) MarkUserTemporarilyBlocked(ctx context.Context, userId int, blockedUntil time.Time) {
 	key := r.getUserBlockKey(userId)
-	r.Set(ctx, key, "1", retryAfter)
+	// Calculate how long from now until the block expires
+	ttl := time.Until(blockedUntil)
+	if ttl > 0 {
+		r.Set(ctx, key, blockedUntil.Format(time.RFC3339), ttl)
+
+		// Invalidate cached rate limit info for this user
+		r.cacheMutex.Lock()
+		delete(r.rateLimitCache, userId)
+		r.cacheMutex.Unlock()
+	}
 }
 
 // IsUserTemporarilyBlocked returns true if the user is currently blocked.
@@ -46,4 +66,113 @@ func (r *RedisClient) RecordOsmLatency(endpoint string, statusCode int, latency 
 		// If we got a 200, ensure the service blocked flag is cleared in Redis.
 		r.Del(context.Background(), osmServiceBlockedKey)
 	}
+}
+
+// UpdateUserRateLimit stores the current rate limit information for a user
+func (r *RedisClient) UpdateUserRateLimit(ctx context.Context, userId int, remaining, limit, resetSeconds int) {
+	now := time.Now()
+
+	// Get block info (stored separately in the block key)
+	blockedUntil := r.getUserBlockEndTime(ctx, userId)
+	isBlocked := !blockedUntil.IsZero() && blockedUntil.After(now)
+
+	info := &osm.UserRateLimitInfo{
+		Remaining:    remaining,
+		Limit:        limit,
+		ResetSeconds: resetSeconds,
+		IsBlocked:    isBlocked,
+		BlockedUntil: blockedUntil,
+		LastUpdated:  now,
+	}
+
+	// Store in Redis
+	key := r.getUserRateLimitKey(userId)
+	data, err := json.Marshal(info)
+	if err != nil {
+		return
+	}
+	r.Set(ctx, key, data, rateLimitRedisTTL)
+
+	// Update in-memory cache
+	r.cacheMutex.Lock()
+	r.rateLimitCache[userId] = &cachedRateLimitInfo{
+		info:      info,
+		expiresAt: now.Add(rateLimitCacheTTL),
+	}
+	r.cacheMutex.Unlock()
+}
+
+// GetUserRateLimitInfo retrieves the current rate limit state for a user
+func (r *RedisClient) GetUserRateLimitInfo(ctx context.Context, userId int) (*osm.UserRateLimitInfo, error) {
+	now := time.Now()
+
+	// Check in-memory cache first
+	r.cacheMutex.RLock()
+	cached, exists := r.rateLimitCache[userId]
+	r.cacheMutex.RUnlock()
+
+	if exists && now.Before(cached.expiresAt) {
+		// Update block status in case it changed
+		isBlocked := r.IsUserTemporarilyBlocked(userId)
+		if isBlocked != cached.info.IsBlocked {
+			// Block status changed, invalidate cache
+			r.cacheMutex.Lock()
+			delete(r.rateLimitCache, userId)
+			r.cacheMutex.Unlock()
+		} else {
+			return cached.info, nil
+		}
+	}
+
+	// Cache miss or expired - fetch from Redis
+	key := r.getUserRateLimitKey(userId)
+	data, err := r.Get(ctx, key).Result()
+	if err != nil {
+		if err == redis.Nil {
+			return nil, nil // No rate limit info available
+		}
+		return nil, fmt.Errorf("failed to get rate limit info from Redis: %w", err)
+	}
+
+	var info osm.UserRateLimitInfo
+	if err := json.Unmarshal([]byte(data), &info); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal rate limit info: %w", err)
+	}
+
+	// Update block status (it might have changed)
+	blockedUntil := r.getUserBlockEndTime(ctx, userId)
+	info.IsBlocked = !blockedUntil.IsZero() && blockedUntil.After(now)
+	info.BlockedUntil = blockedUntil
+
+	// Store in cache
+	r.cacheMutex.Lock()
+	r.rateLimitCache[userId] = &cachedRateLimitInfo{
+		info:      &info,
+		expiresAt: now.Add(rateLimitCacheTTL),
+	}
+	r.cacheMutex.Unlock()
+
+	return &info, nil
+}
+
+func (r *RedisClient) getUserRateLimitKey(userId int) string {
+	return osmUserRateLimitPrefix + strconv.Itoa(userId)
+}
+
+// getUserBlockEndTime retrieves the block end time for a user from Redis.
+// Returns zero time if the user is not blocked.
+func (r *RedisClient) getUserBlockEndTime(ctx context.Context, userId int) time.Time {
+	key := r.getUserBlockKey(userId)
+	val, err := r.Get(ctx, key).Result()
+	if err != nil {
+		return time.Time{} // Not blocked or error
+	}
+
+	// Parse the stored timestamp
+	blockedUntil, err := time.Parse(time.RFC3339, val)
+	if err != nil {
+		return time.Time{}
+	}
+
+	return blockedUntil
 }

--- a/internal/db/redis.go
+++ b/internal/db/redis.go
@@ -3,14 +3,26 @@ package db
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
+	"github.com/m0rjc/OsmDeviceAdapter/internal/osm"
 	"github.com/redis/go-redis/v9"
 )
+
+// cachedRateLimitInfo holds rate limit info with expiry for in-memory caching
+type cachedRateLimitInfo struct {
+	info      *osm.UserRateLimitInfo
+	expiresAt time.Time
+}
 
 type RedisClient struct {
 	client    *redis.Client
 	keyPrefix string
+
+	// In-memory cache for rate limit info to reduce Redis hits
+	rateLimitCache map[int]*cachedRateLimitInfo
+	cacheMutex     sync.RWMutex
 }
 
 func NewRedisClient(redisURL string, keyPrefix string) (*RedisClient, error) {
@@ -28,8 +40,9 @@ func NewRedisClient(redisURL string, keyPrefix string) (*RedisClient, error) {
 	}
 
 	return &RedisClient{
-		client:    client,
-		keyPrefix: keyPrefix,
+		client:         client,
+		keyPrefix:      keyPrefix,
+		rateLimitCache: make(map[int]*cachedRateLimitInfo),
 	}, nil
 }
 

--- a/internal/osm/prometheus.go
+++ b/internal/osm/prometheus.go
@@ -27,13 +27,21 @@ func (p *PrometheusRateLimitDecorator) IsOsmServiceBlocked(ctx context.Context) 
 	return p.next.IsOsmServiceBlocked(ctx)
 }
 
-func (p *PrometheusRateLimitDecorator) MarkUserTemporarilyBlocked(ctx context.Context, userId int, retryAfter time.Duration) {
-	p.next.MarkUserTemporarilyBlocked(ctx, userId, retryAfter)
+func (p *PrometheusRateLimitDecorator) MarkUserTemporarilyBlocked(ctx context.Context, userId int, blockedUntil time.Time) {
+	p.next.MarkUserTemporarilyBlocked(ctx, userId, blockedUntil)
 	metrics.OSMBlockCount.Inc()
 }
 
 func (p *PrometheusRateLimitDecorator) IsUserTemporarilyBlocked(userId int) bool {
 	return p.next.IsUserTemporarilyBlocked(userId)
+}
+
+func (p *PrometheusRateLimitDecorator) UpdateUserRateLimit(ctx context.Context, userId int, remaining, limit, resetSeconds int) {
+	p.next.UpdateUserRateLimit(ctx, userId, remaining, limit, resetSeconds)
+}
+
+func (p *PrometheusRateLimitDecorator) GetUserRateLimitInfo(ctx context.Context, userId int) (*UserRateLimitInfo, error) {
+	return p.next.GetUserRateLimitInfo(ctx, userId)
 }
 
 // PrometheusLatencyRecorder is LatencyRecorder that records latency metrics to Prometheus.


### PR DESCRIPTION
This refactoring enhances the rate limit store to provide complete rate limit state tracking with in-memory caching to reduce Redis hits.

Changes:
- Enhanced RateLimitStore interface with UpdateUserRateLimit() and GetUserRateLimitInfo() methods to track and retrieve rate limit state
- Store block end time as absolute timestamp instead of duration for accurate expiry tracking
- Added UserRateLimitInfo struct to encapsulate rate limit state including remaining requests, limit, reset time, block status, and block expiry time
- Implemented in-memory cache with 30-second TTL in RedisClient to minimize Redis hits for rate limit queries
- Removed unused RateLimit field from Response struct - rate limit info is now stored directly in the store
- Updated PatrolScoreService to use rate limit info for intelligent cache TTL calculation based on degraded/blocked state
- Updated all tests and mocks to support new interface

The rate limit store now maintains complete state and can answer queries about current rate limit status and block expiry times, enabling the patrol score service to make informed caching decisions.