### PR TITLE
Make OAuth endpoints configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ All configuration is provided via environment variables:
 | `DEVICE_CODE_EXPIRY` | Device code expiry in seconds | No | `600` |
 | `DEVICE_POLL_INTERVAL` | Recommended polling interval | No | `5` |
 | `ALLOWED_CLIENT_IDS` | Comma-separated list of allowed OAuth client IDs | Yes | - |
+| `OAUTH_PATH_PREFIX` | OAuth web flow path prefix (for obscurity) | No | `/oauth` |
+| `DEVICE_PATH_PREFIX` | Device flow path prefix (for obscurity) | No | `/device` |
+| `API_PATH_PREFIX` | API endpoints path prefix (for obscurity) | No | `/api` |
 
 ## Database Schema
 

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -10,6 +10,16 @@ data:
   device-code-expiry: {{ .Values.config.deviceCodeExpiry | quote }}
   device-poll-interval: {{ .Values.config.devicePollInterval | quote }}
   allowed-client-ids: {{ .Values.config.allowedClientIds | join "," | quote }}
+  # Path configuration for endpoint obscurity
+  {{- if .Values.config.paths.oauthPrefix }}
+  oauth-path-prefix: {{ .Values.config.paths.oauthPrefix | quote }}
+  {{- end }}
+  {{- if .Values.config.paths.devicePrefix }}
+  device-path-prefix: {{ .Values.config.paths.devicePrefix | quote }}
+  {{- end }}
+  {{- if .Values.config.paths.apiPrefix }}
+  api-path-prefix: {{ .Values.config.paths.apiPrefix | quote }}
+  {{- end }}
   # Device endpoint rate limiting
   device-authorize-rate-limit: {{ .Values.config.deviceRateLimit.authorize | quote }}
   device-entry-rate-limit: {{ .Values.config.deviceRateLimit.entry | quote }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -116,6 +116,28 @@ spec:
             configMapKeyRef:
               name: {{ include "osm-device-adapter.fullname" . }}
               key: allowed-client-ids
+        # Path prefixes for endpoint obscurity
+        {{- if .Values.config.paths.oauthPrefix }}
+        - name: OAUTH_PATH_PREFIX
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "osm-device-adapter.fullname" . }}
+              key: oauth-path-prefix
+        {{- end }}
+        {{- if .Values.config.paths.devicePrefix }}
+        - name: DEVICE_PATH_PREFIX
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "osm-device-adapter.fullname" . }}
+              key: device-path-prefix
+        {{- end }}
+        {{- if .Values.config.paths.apiPrefix }}
+        - name: API_PATH_PREFIX
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "osm-device-adapter.fullname" . }}
+              key: api-path-prefix
+        {{- end }}
         # Device endpoint rate limiting
         - name: DEVICE_AUTHORIZE_RATE_LIMIT
           valueFrom:

--- a/chart/values-example.yaml
+++ b/chart/values-example.yaml
@@ -26,6 +26,15 @@ config:
     - "scoreboard-device-123"
     - "scoreboard-device-456"
 
+  # Path configuration (for security through obscurity - makes endpoints less predictable)
+  paths:
+    # OAuth web flow path prefix (default: /oauth)
+    oauthPrefix: "/oauth"
+    # Device flow path prefix (default: /device)
+    devicePrefix: "/device"
+    # API endpoints path prefix (default: /api)
+    apiPrefix: "/api"
+
   # Rate limiting configuration for OAuth endpoints (protects against abuse)
   deviceRateLimit:
     # Maximum requests per minute per IP for /device/authorize

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -98,6 +98,15 @@ config:
   # Allowed client IDs that can use the device flow (empty list allows all)
   allowedClientIds: []
 
+  # Path configuration (for security through obscurity - makes endpoints less predictable)
+  paths:
+    # OAuth web flow path prefix (default: /oauth)
+    oauthPrefix: "/oauth"
+    # Device flow path prefix (default: /device)
+    devicePrefix: "/device"
+    # API endpoints path prefix (default: /api)
+    apiPrefix: "/api"
+
   # Rate limiting configuration for OAuth endpoints
   deviceRateLimit:
     # Maximum requests per minute per IP for /device/authorize


### PR DESCRIPTION
Implements configurable path prefixes for OAuth, device, and API endpoints to make them less predictable to automated scanners and vulnerability probes.

Changes:
- Add PathConfig struct with OAUTH_PATH_PREFIX, DEVICE_PATH_PREFIX, and API_PATH_PREFIX
- Update server route registration to use configurable paths
- Update handlers to construct URLs using configured path prefixes
- Update redirect URI computation to use configured OAuth path
- Update Helm chart templates and values to support path configuration
- Update documentation (CLAUDE.md and README.md)

Default values maintain backward compatibility:
- OAUTH_PATH_PREFIX: /oauth
- DEVICE_PATH_PREFIX: /device
- API_PATH_PREFIX: /api

All paths are normalized to remove trailing slashes during config loading.