### PR TITLE
Sort patrols by score in descending order

### DIFF
--- a/internal/osm/patrol_scores.go
+++ b/internal/osm/patrol_scores.go
@@ -116,9 +116,9 @@ func (c *Client) FetchPatrolScores(ctx context.Context, user types.User, section
 		})
 	}
 
-	// Sort patrols by name for consistent ordering
+	// Sort patrols by score in descending order (highest first)
 	sort.Slice(patrols, func(i, j int) bool {
-		return patrols[i].Name < patrols[j].Name
+		return patrols[i].Score > patrols[j].Score
 	})
 
 	slog.Info("osm.patrol_scores.success",


### PR DESCRIPTION
Updated FetchPatrolScores to sort patrols by score (highest first) instead of alphabetically by name. This provides a more useful default ordering for clients displaying patrol standings.