### PR TITLE
Reduce metrics sent to Grafana

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -47,8 +47,8 @@ func NewMetricsServer(deps *handlers.Dependencies) *http.Server {
 	mux.HandleFunc("/health", handlers.HealthHandler)
 	mux.HandleFunc("/ready", handlers.ReadyHandler(deps))
 
-	// Prometheus metrics endpoint
-	mux.Handle("/metrics", promhttp.Handler())
+	// Prometheus metrics endpoint (using custom registry without Go runtime metrics)
+	mux.Handle("/metrics", promhttp.HandlerFor(metrics.Registry, promhttp.HandlerOpts{}))
 
 	return &http.Server{
 		Addr:    ":9090",


### PR DESCRIPTION
The Prometheus client was automatically exporting 20+ Go runtime metrics (go_memstats_*, process_*, go_goroutines, etc.) that were not being used in any dashboards and were contributing to exceeding Grafana free tier limits.

Changes:
- Created custom Prometheus registry that excludes Go runtime collectors
- Removed dependency on promauto package (which uses default registry)
- Manually register only application-specific metrics
- Updated server to use custom registry with promhttp.HandlerFor()
- Updated documentation to reflect the change

This reduces metric cardinality significantly while retaining all metrics used in the dashboards:
- osm_rate_limit_* (rate limiting)
- osm_service_blocked (blocking detection)
- device_auth_requests_total (OAuth)
- osm_api_request_duration_seconds (API latency)
- cache_operations_total (cache metrics)
- http_request_duration_seconds (HTTP metrics)
- http_requests_total (HTTP request counts)