### PR TITLE
Migrate device flow client IDs to database

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,7 +42,7 @@ type RedisConfig struct {
 type DeviceOAuthConfig struct {
 	DeviceCodeExpiry   int    `key:"DEVICE_CODE_EXPIRY" default:"300" min:"60"` // seconds (5 minutes default)
 	DevicePollInterval int    `key:"DEVICE_POLL_INTERVAL" default:"5" min:"1"`  // seconds
-	AllowedClientIDs   string `key:"ALLOWED_CLIENT_IDS" required:"true"`        // Comma-separated list
+	AllowedClientIDs   string `key:"ALLOWED_CLIENT_IDS"`                        // DEPRECATED: Use database table instead. Comma-separated list for backward compatibility.
 }
 
 // RateLimitConfig holds rate limiting configuration

--- a/internal/db/allowed_client_id_store.go
+++ b/internal/db/allowed_client_id_store.go
@@ -1,0 +1,59 @@
+package db
+
+import (
+	"errors"
+
+	"gorm.io/gorm"
+)
+
+// IsClientIDAllowed checks if a client ID is in the database and enabled.
+// Returns (allowed bool, allowedClientID int, error).
+// If allowed is false, allowedClientID will be 0.
+func IsClientIDAllowed(conns *Connections, clientID string) (bool, int, error) {
+	var record AllowedClientID
+	err := conns.DB.Where("client_id = ? AND enabled = ?", clientID, true).First(&record).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return false, 0, nil
+		}
+		return false, 0, err
+	}
+	return true, record.ID, nil
+}
+
+// CreateAllowedClientID creates a new allowed client ID record
+func CreateAllowedClientID(conns *Connections, clientID *AllowedClientID) error {
+	return conns.DB.Create(clientID).Error
+}
+
+// FindAllowedClientID finds an allowed client ID by its client_id field
+func FindAllowedClientID(conns *Connections, clientID string) (*AllowedClientID, error) {
+	var record AllowedClientID
+	err := conns.DB.Where("client_id = ?", clientID).First(&record).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &record, nil
+}
+
+// UpdateAllowedClientIDEnabled updates the enabled status of a client ID
+func UpdateAllowedClientIDEnabled(conns *Connections, clientID string, enabled bool) error {
+	return conns.DB.Model(&AllowedClientID{}).
+		Where("client_id = ?", clientID).
+		Update("enabled", enabled).Error
+}
+
+// ListAllowedClientIDs returns all allowed client IDs (enabled and disabled)
+func ListAllowedClientIDs(conns *Connections) ([]AllowedClientID, error) {
+	var records []AllowedClientID
+	err := conns.DB.Order("created_at DESC").Find(&records).Error
+	return records, err
+}
+
+// DeleteAllowedClientID deletes an allowed client ID record
+func DeleteAllowedClientID(conns *Connections, clientID string) error {
+	return conns.DB.Where("client_id = ?", clientID).Delete(&AllowedClientID{}).Error
+}

--- a/internal/handlers/device_oauth_test.go
+++ b/internal/handlers/device_oauth_test.go
@@ -217,40 +217,6 @@ func TestDeviceAuthorizeHandler_MultipleAllowedClients(t *testing.T) {
 	}
 }
 
-func TestIsClientIDAllowed(t *testing.T) {
-	allowedClients := []string{"client-1", "client-2", "client-3"}
-
-	tests := []struct {
-		name     string
-		clientID string
-		expected bool
-	}{
-		{"Valid client 1", "client-1", true},
-		{"Valid client 2", "client-2", true},
-		{"Valid client 3", "client-3", true},
-		{"Invalid client", "unauthorized", false},
-		{"Empty client", "", false},
-		{"Similar but not exact", "client-", false},
-		{"Case sensitive", "Client-1", false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := isClientIDAllowed(tt.clientID, allowedClients)
-			if result != tt.expected {
-				t.Errorf("isClientIDAllowed(%q) = %v, expected %v", tt.clientID, result, tt.expected)
-			}
-		})
-	}
-}
-
-func TestIsClientIDAllowed_EmptyWhitelist(t *testing.T) {
-	result := isClientIDAllowed("any-client", []string{})
-	if result != false {
-		t.Error("Expected isClientIDAllowed to return false with empty whitelist")
-	}
-}
-
 func TestGenerateDeviceAccessToken(t *testing.T) {
 	token1, err := generateDeviceAccessToken()
 	if err != nil {


### PR DESCRIPTION
- Add allowed_client_ids table with surrogate primary key
- Support client ID rotation via surrogate key design
- Track client metadata: comment, contact_email, enabled flag
- Add created_by_id foreign key to device_codes for audit trail
- Deprecate ALLOWED_CLIENT_IDS environment variable
- Update all documentation with database management instructions

Database schema:
- allowed_client_ids.id: Auto-increment primary key
- allowed_client_ids.client_id: Unique, rotatable identifier
- device_codes.created_by_id: References allowed_client_ids.id

Benefits:
- Client ID rotation without breaking foreign keys
- Rich metadata for each client (comment, contact email)
- Enable/disable clients without deletion
- Better audit trail and management flexibility
- Manual SQL-based management (admin API future enhancement)