### PR TITLE
Refactor OAuth token refresh to use central service with callbacks

### DIFF
--- a/internal/deviceauth/service.go
+++ b/internal/deviceauth/service.go
@@ -4,37 +4,33 @@ import (
 	"context"
 	"errors"
 	"log/slog"
-	"strings"
 	"time"
 
 	"github.com/m0rjc/OsmDeviceAdapter/internal/db"
 	"github.com/m0rjc/OsmDeviceAdapter/internal/db/devicecode"
+	"github.com/m0rjc/OsmDeviceAdapter/internal/osm"
+	"github.com/m0rjc/OsmDeviceAdapter/internal/tokenrefresh"
 	"github.com/m0rjc/OsmDeviceAdapter/internal/types"
 )
 
 // Authentication errors
 var (
 	ErrInvalidToken       = errors.New("invalid access token")
-	ErrTokenRevoked       = errors.New("OSM access revoked by user")
-	ErrTokenRefreshFailed = errors.New("temporary failure refreshing token")
+	ErrTokenRevoked       = tokenrefresh.ErrTokenRevoked
+	ErrTokenRefreshFailed = tokenrefresh.ErrTokenRefreshFailed
 )
-
-// OAuthClient defines the interface for OAuth operations needed by the service
-type OAuthClient interface {
-	RefreshToken(ctx context.Context, refreshToken string) (*types.OSMTokenResponse, error)
-}
 
 // Service handles device authentication and authorization
 type Service struct {
-	conns   *db.Connections
-	osmAuth OAuthClient
+	conns          *db.Connections
+	tokenRefresher osm.TokenRefresher
 }
 
 // NewService creates a new device auth service
-func NewService(conns *db.Connections, osmAuth OAuthClient) *Service {
+func NewService(conns *db.Connections, tokenRefresher osm.TokenRefresher) *Service {
 	return &Service{
-		conns:   conns,
-		osmAuth: osmAuth,
+		conns:          conns,
+		tokenRefresher: tokenRefresher,
 	}
 }
 
@@ -87,9 +83,8 @@ func (s *Service) Authenticate(ctx context.Context, authHeader string) (types.Us
 	// Check if we need to refresh the OSM token
 	if deviceCodeRecord.OSMTokenExpiry != nil && time.Now().After(deviceCodeRecord.OSMTokenExpiry.Add(-5*time.Minute)) {
 		// Token is expired or about to expire, refresh it
-		newAccessToken, err := s.RefreshUserTokenFromRecord(ctx, deviceCodeRecord)
+		newAccessToken, err := s.refreshDeviceToken(ctx, deviceCodeRecord)
 		if err != nil {
-			// RefreshUserTokenFromRecord already handles logging and database updates
 			return nil, err
 		}
 
@@ -113,86 +108,36 @@ func (s *Service) Authenticate(ctx context.Context, authHeader string) (types.Us
 	}, nil
 }
 
-// RefreshUserTokenFromRecord implements the osm.TokenRefresher interface.
-// It attempts to refresh the OSM access token for the given device code record.
-// If refresh fails with 401 (user revoked access), it marks the device as revoked.
-// Returns the new access token on success, or an error if refresh fails.
-func (s *Service) RefreshUserTokenFromRecord(ctx context.Context, deviceCodeRecordInterface interface{}) (string, error) {
-	// Type assert the interface{} to *db.DeviceCode
-	deviceCodeRecord, ok := deviceCodeRecordInterface.(*db.DeviceCode)
-	if !ok {
-		slog.Error("deviceauth.refresh_user_token.invalid_type",
-			"component", "deviceauth",
-			"event", "token.refresh_error",
-			"error", "deviceCodeRecord is not *db.DeviceCode",
-		)
-		return "", ErrInvalidToken
+// refreshDeviceToken refreshes the OSM token for a device using the central token refresh service.
+func (s *Service) refreshDeviceToken(ctx context.Context, deviceCodeRecord *db.DeviceCode) (string, error) {
+	refreshToken := ""
+	if deviceCodeRecord.OSMRefreshToken != nil {
+		refreshToken = *deviceCodeRecord.OSMRefreshToken
 	}
 
-	deviceCode := deviceCodeRecord.DeviceCode
+	identifier := deviceCodeRecord.DeviceCode[:8]
 
-	// Get the refresh token
-	if deviceCodeRecord.OSMRefreshToken == nil {
-		slog.Error("deviceauth.refresh_user_token.no_refresh_token",
-			"component", "deviceauth",
-			"event", "token.refresh_error",
-			"device_code_hash", deviceCode[:8],
-		)
-		return "", ErrTokenRefreshFailed
-	}
-
-	// Attempt to refresh the token
-	newTokens, err := s.osmAuth.RefreshToken(ctx, *deviceCodeRecord.OSMRefreshToken)
-	if err != nil {
-		// Check if this is an authorization error (user revoked access) // FIXME: Use sentinel error here.
-		if strings.Contains(err.Error(), "unauthorized (revoked)") {
-			slog.Warn("deviceauth.refresh_user_token.revoked",
-				"component", "deviceauth",
-				"event", "token.revoked",
-				"device_code_hash", deviceCode[:8],
-				"error", err,
-			)
-			// Mark device as revoked in database
-			if revokeErr := devicecode.Revoke(s.conns, deviceCode); revokeErr != nil {
-				slog.Error("deviceauth.refresh_user_token.revoke_failed",
-					"component", "deviceauth",
-					"event", "token.revoke_error",
-					"device_code_hash", deviceCode[:8],
-					"error", revokeErr,
-				)
-			}
-			return "", ErrTokenRevoked
-		}
-
-		// Temporary error (network, OSM server issue, etc.)
-		slog.Error("deviceauth.refresh_user_token.failed",
-			"component", "deviceauth",
-			"event", "token.refresh_error",
-			"device_code_hash", deviceCode[:8],
-			"error", err,
-		)
-		return "", ErrTokenRefreshFailed
-	}
-
-	// Update tokens in database
-	newExpiry := time.Now().Add(time.Duration(newTokens.ExpiresIn) * time.Second)
-	if err := devicecode.UpdateTokensOnly(s.conns, deviceCode, newTokens.AccessToken, newTokens.RefreshToken, newExpiry); err != nil {
-		slog.Error("deviceauth.refresh_user_token.update_failed",
-			"component", "deviceauth",
-			"event", "token.update_error",
-			"device_code_hash", deviceCode[:8],
-			"error", err,
-		)
-		return "", ErrTokenRefreshFailed
-	}
-
-	slog.Info("deviceauth.refresh_user_token.success",
-		"component", "deviceauth",
-		"event", "token.refreshed",
-		"device_code_hash", deviceCode[:8],
+	return s.tokenRefresher.RefreshToken(
+		ctx,
+		refreshToken,
+		identifier,
+		// onSuccess: update tokens in database
+		func(accessToken, newRefreshToken string, expiry time.Time) error {
+			return devicecode.UpdateTokensOnly(s.conns, deviceCodeRecord.DeviceCode, accessToken, newRefreshToken, expiry)
+		},
+		// onRevoked: mark device as revoked
+		func() error {
+			return devicecode.Revoke(s.conns, deviceCodeRecord.DeviceCode)
+		},
 	)
+}
 
-	return newTokens.AccessToken, nil
+// CreateRefreshFunc creates a bound refresh function for a device code record.
+// This function can be stored in context for automatic token refresh on 401.
+func (s *Service) CreateRefreshFunc(deviceCodeRecord *db.DeviceCode) types.TokenRefreshFunc {
+	return func(ctx context.Context) (string, error) {
+		return s.refreshDeviceToken(ctx, deviceCodeRecord)
+	}
 }
 
 // extractBearerToken extracts the token from a Bearer authorization header

--- a/internal/handlers/admin_oauth_test.go
+++ b/internal/handlers/admin_oauth_test.go
@@ -21,7 +21,7 @@ import (
 
 // newMockOSMClient creates an OSM client for testing that uses the provided base URL
 func newMockOSMClient(baseURL string) *osm.Client {
-	return osm.NewClient(baseURL, nil, nil, nil)
+	return osm.NewClient(baseURL, nil, nil)
 }
 
 // setupAdminTestDeps creates test dependencies with miniredis for admin OAuth tests

--- a/internal/osm/client.go
+++ b/internal/osm/client.go
@@ -10,15 +10,13 @@ type Client struct {
 	httpClient *http.Client
 	rlStore    RateLimitStore
 	recorder   LatencyRecorder
-	refresher  TokenRefresher
 }
 
-func NewClient(baseURL string, rlStore RateLimitStore, recorder LatencyRecorder, refresher TokenRefresher) *Client {
+func NewClient(baseURL string, rlStore RateLimitStore, recorder LatencyRecorder) *Client {
 	return &Client{
-		baseURL:   baseURL,
-		rlStore:   rlStore,
-		recorder:  recorder,
-		refresher: refresher,
+		baseURL:  baseURL,
+		rlStore:  rlStore,
+		recorder: recorder,
 		httpClient: &http.Client{
 			Timeout: 10 * time.Second,
 		},

--- a/internal/osm/oauthclient/oauth.go
+++ b/internal/osm/oauthclient/oauth.go
@@ -3,6 +3,7 @@ package oauthclient
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -11,6 +12,10 @@ import (
 
 	"github.com/m0rjc/OsmDeviceAdapter/internal/types"
 )
+
+// ErrAccessRevoked indicates the user has revoked OAuth access.
+// This is returned when a token refresh attempt receives a 401 Unauthorized response.
+var ErrAccessRevoked = errors.New("OSM access revoked by user")
 
 func New(clientId, clientSecret, redirectUri, osmDomain string) *WebFlowClient {
 	return &WebFlowClient{
@@ -53,7 +58,7 @@ func (c *WebFlowClient) RefreshToken(ctx context.Context, refreshToken string) (
 
 	// Check for 401 (user revoked access)
 	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, fmt.Errorf("OSM access unauthorized (revoked)")
+		return nil, ErrAccessRevoked
 	}
 
 	// Check for other non-2xx status codes

--- a/internal/osm/request.go
+++ b/internal/osm/request.go
@@ -66,12 +66,24 @@ type LatencyRecorder interface {
 }
 
 // TokenRefresher handles refreshing expired or expiring OSM access tokens.
-// Implementations should refresh the token, update the database, and handle revocation.
+// It uses callbacks to allow callers to handle storage updates and revocation
+// in a type-specific way (device codes vs web sessions).
 type TokenRefresher interface {
-	// RefreshUserTokenFromRecord attempts to refresh the OSM access token for the given device.
+	// RefreshToken attempts to refresh the OSM access token.
+	// Parameters:
+	//   - ctx: context for the request
+	//   - refreshToken: the current refresh token
+	//   - identifier: a short identifier for logging (e.g., first 8 chars of device code or session ID)
+	//   - onSuccess: called with new tokens when refresh succeeds; should persist to storage
+	//   - onRevoked: called when the user has revoked access (401 from OSM); should clean up
 	// Returns the new access token on success, or an error if refresh fails.
-	// If the token was revoked by the user (401 from OSM), the device should be marked as revoked.
-	RefreshUserTokenFromRecord(ctx context.Context, deviceCodeRecord interface{}) (newAccessToken string, err error)
+	RefreshToken(
+		ctx context.Context,
+		refreshToken string,
+		identifier string,
+		onSuccess func(accessToken, refreshToken string, expiry time.Time) error,
+		onRevoked func() error,
+	) (newAccessToken string, err error)
 }
 
 // requestConfig holds the configuration for a single OSM API request.
@@ -328,76 +340,11 @@ func (c *Client) Request(ctx context.Context, method string, target any, options
 	}
 
 	// Handle 401 Unauthorized - attempt token refresh and retry
-	// Only attempt if we have a refresher and haven't already retried
-	if resp.StatusCode == http.StatusUnauthorized && c.refresher != nil && !config.retryAttempted {
-		slog.Info("osm.api.unauthorized_attempting_refresh",
-			"component", "osm_api",
-			"event", "api.retry",
-			"endpoint", endpoint,
-		)
-
-		// Extract device code from context (must be authenticated device request)
-		user, ok := ctx.Value(types.UserContextKey).(types.User)
-		if !ok {
-			slog.Debug("osm.api.no_user_in_context_for_retry",
-				"component", "osm_api",
-				"event", "api.retry.skip",
-				"endpoint", endpoint,
-			)
-			// No user in context - not a device request, can't refresh
-		} else {
-			// Type assert to get device code
-			type DeviceCodeProvider interface {
-				DeviceCode() interface{}
-			}
-			if authCtx, ok := user.(DeviceCodeProvider); ok {
-				deviceCodeRecord := authCtx.DeviceCode()
-
-				// Attempt to refresh the token
-				newToken, err := c.refresher.RefreshUserTokenFromRecord(ctx, deviceCodeRecord)
-				if err == nil {
-					// Token refresh succeeded - retry the request with the new token
-					slog.Info("osm.api.retry_with_new_token",
-						"component", "osm_api",
-						"event", "api.retry.success",
-						"endpoint", endpoint,
-					)
-
-					// Rebuild options with updated config
-					retryOptions := []RequestOption{
-						WithPath(config.path),
-						WithUser(types.NewUser(config.userId, newToken)),
-					}
-					if len(config.queryParameters) > 0 {
-						retryOptions = append(retryOptions, WithQueryParameters(config.queryParameters))
-					}
-					if config.sensitive {
-						retryOptions = append(retryOptions, WithSensitive())
-					}
-					if config.body != nil {
-						retryOptions = append(retryOptions, WithPostBody(config.body))
-					}
-					if config.contentType != "" {
-						retryOptions = append(retryOptions, WithContentType(config.contentType))
-					}
-
-					// Mark that we've already attempted a retry to prevent infinite loops
-					retryOptions = append(retryOptions, func(c *requestConfig) {
-						c.retryAttempted = true
-					})
-
-					// Retry the request
-					return c.Request(ctx, method, target, retryOptions...)
-				}
-
-				// Token refresh failed - log and continue to error handling below
-				// (RefreshUserTokenFromRecord already logged details)
-				slog.Debug("osm.api.token_refresh_failed_continuing",
-					"component", "osm_api",
-					"event", "api.retry.failed",
-					"endpoint", endpoint,
-				)
-			}
+	if resp.StatusCode == http.StatusUnauthorized && !config.retryAttempted {
+		// This method will return nil if it's not possible to refresh, so allowing
+		// passthrough to normal error handling.
+		if retryOpts := c.attemptTokenRefreshAndRetry(ctx, options, endpoint); retryOpts != nil {
+			return c.Request(ctx, method, target, retryOpts...)
 		}
 	}
 
@@ -438,6 +385,62 @@ func (c *Client) Request(ctx context.Context, method string, target any, options
 	}
 
 	return osmResponse, nil
+}
+
+// attemptTokenRefreshAndRetry attempts to refresh an expired token and build retry options.
+// Returns the retry options if refresh succeeded, or nil if refresh failed or wasn't possible.
+// The returned options replay the original options with the new token appended (overriding the old one).
+func (c *Client) attemptTokenRefreshAndRetry(ctx context.Context, originalOptions []RequestOption, endpoint string) []RequestOption {
+	refreshFunc, hasRefresh := ctx.Value(types.TokenRefreshFuncKey).(types.TokenRefreshFunc)
+	if !hasRefresh {
+		return nil
+	}
+
+	slog.Info("osm.api.unauthorized_attempting_refresh",
+		"component", "osm_api",
+		"event", "api.retry",
+		"endpoint", endpoint,
+	)
+
+	newToken, err := refreshFunc(ctx)
+	if err != nil {
+		slog.Debug("osm.api.token_refresh_failed_continuing",
+			"component", "osm_api",
+			"event", "api.retry.failed",
+			"endpoint", endpoint,
+		)
+		return nil
+	}
+
+	slog.Info("osm.api.retry_with_new_token",
+		"component", "osm_api",
+		"event", "api.retry.success",
+		"endpoint", endpoint,
+	)
+
+	// Replay original options, then override with new token and mark as retry
+	retryOptions := make([]RequestOption, len(originalOptions), len(originalOptions)+2)
+	copy(retryOptions, originalOptions)
+	retryOptions = append(retryOptions,
+		withNewToken(newToken),
+		withRetryAttempted(),
+	)
+
+	return retryOptions
+}
+
+// withNewToken returns an option that updates just the user token (preserving userId).
+func withNewToken(token string) RequestOption {
+	return func(c *requestConfig) {
+		c.userToken = token
+	}
+}
+
+// withRetryAttempted marks the request as a retry to prevent infinite loops.
+func withRetryAttempted() RequestOption {
+	return func(c *requestConfig) {
+		c.retryAttempted = true
+	}
 }
 
 func parseRetryAfterHeader(str string, defaultSeconds int) time.Time {

--- a/internal/osm/request_test.go
+++ b/internal/osm/request_test.go
@@ -87,7 +87,7 @@ func TestClient_Request(t *testing.T) {
 		defer server.Close()
 
 		store := &mockStore{}
-		client := NewClient(server.URL, store, store, nil)
+		client := NewClient(server.URL, store, store)
 
 		var target map[string]string
 		resp, err := client.Request(context.Background(), http.MethodGet, &target, WithPath("/test"), WithUser(newMockUser(1, "test-token")))
@@ -108,7 +108,7 @@ func TestClient_Request(t *testing.T) {
 
 	t.Run("service blocked in store", func(t *testing.T) {
 		store := &mockStore{serviceBlocked: true}
-		client := NewClient("http://osm.local", store, store, nil)
+		client := NewClient("http://osm.local", store, store)
 
 		_, err := client.Request(context.Background(), http.MethodGet, nil, WithPath("/test"))
 		if err != ErrServiceBlocked {
@@ -122,7 +122,7 @@ func TestClient_Request(t *testing.T) {
 			userBlocked:      map[int]bool{1: true},
 			userBlockedUntil: map[int]time.Time{1: blockTime},
 		}
-		client := NewClient("http://osm.local", store, store, nil)
+		client := NewClient("http://osm.local", store, store)
 
 		_, err := client.Request(context.Background(), http.MethodGet, nil, WithPath("/test"), WithUser(newMockUser(1, "utoken")))
 		var blockedErr *ErrUserBlocked
@@ -139,7 +139,7 @@ func TestClient_Request(t *testing.T) {
 		defer server.Close()
 
 		store := &mockStore{}
-		client := NewClient(server.URL, store, store, nil)
+		client := NewClient(server.URL, store, store)
 
 		_, err := client.Request(context.Background(), http.MethodGet, nil, WithPath("/test"))
 		if err == nil || !strings.Contains(err.Error(), "OSM service blocked") {
@@ -158,7 +158,7 @@ func TestClient_Request(t *testing.T) {
 		defer server.Close()
 
 		store := &mockStore{}
-		client := NewClient(server.URL, store, store, nil)
+		client := NewClient(server.URL, store, store)
 
 		_, err := client.Request(context.Background(), http.MethodGet, nil, WithPath("/test"), WithUser(newMockUser(1, "utoken")))
 		var blockedErr *ErrUserBlocked
@@ -179,7 +179,7 @@ func TestClient_Request(t *testing.T) {
 		defer server.Close()
 
 		store := &mockStore{}
-		client := NewClient(server.URL, store, store, nil)
+		client := NewClient(server.URL, store, store)
 
 		_, err := client.Request(context.Background(), http.MethodPost, nil, WithPath("/oauth/token"))
 		if err == nil {
@@ -204,7 +204,7 @@ func TestClient_Request(t *testing.T) {
 		defer server.Close()
 
 		store := &mockStore{}
-		client := NewClient(server.URL, store, store, nil)
+		client := NewClient(server.URL, store, store)
 
 		_, err := client.Request(context.Background(), http.MethodGet, nil, WithPath("/test"), WithUser(newMockUser(1, "user-token")))
 		if err != nil {

--- a/internal/tokenrefresh/service.go
+++ b/internal/tokenrefresh/service.go
@@ -1,0 +1,113 @@
+package tokenrefresh
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/m0rjc/OsmDeviceAdapter/internal/osm"
+	"github.com/m0rjc/OsmDeviceAdapter/internal/osm/oauthclient"
+	"github.com/m0rjc/OsmDeviceAdapter/internal/types"
+)
+
+// Errors returned by the token refresh service
+var (
+	ErrTokenRevoked       = errors.New("OSM access revoked by user")
+	ErrTokenRefreshFailed = errors.New("temporary failure refreshing token")
+)
+
+// OAuthClient defines the interface for OAuth operations needed by the service
+type OAuthClient interface {
+	RefreshToken(ctx context.Context, refreshToken string) (*types.OSMTokenResponse, error)
+}
+
+// Service handles OAuth token refresh with proper error handling.
+// It calls the OAuth client and invokes callbacks for storage updates.
+type Service struct {
+	oauthClient OAuthClient
+}
+
+// NewService creates a new token refresh service
+func NewService(oauthClient OAuthClient) *Service {
+	return &Service{
+		oauthClient: oauthClient,
+	}
+}
+
+// RefreshToken implements osm.TokenRefresher interface.
+// It refreshes the OSM access token and calls the appropriate callback.
+func (s *Service) RefreshToken(
+	ctx context.Context,
+	refreshToken string,
+	identifier string,
+	onSuccess func(accessToken, refreshToken string, expiry time.Time) error,
+	onRevoked func() error,
+) (string, error) {
+	if refreshToken == "" {
+		slog.Error("tokenrefresh.no_refresh_token",
+			"component", "tokenrefresh",
+			"event", "token.refresh_error",
+			"identifier", identifier,
+		)
+		return "", ErrTokenRefreshFailed
+	}
+
+	// Attempt to refresh the token
+	newTokens, err := s.oauthClient.RefreshToken(ctx, refreshToken)
+	if err != nil {
+		// Check if this is an authorization error (user revoked access)
+		if errors.Is(err, oauthclient.ErrAccessRevoked) {
+			slog.Warn("tokenrefresh.revoked",
+				"component", "tokenrefresh",
+				"event", "token.revoked",
+				"identifier", identifier,
+			)
+			if onRevoked != nil {
+				if revokeErr := onRevoked(); revokeErr != nil {
+					slog.Error("tokenrefresh.revoke_callback_failed",
+						"component", "tokenrefresh",
+						"event", "token.revoke_error",
+						"identifier", identifier,
+						"error", revokeErr,
+					)
+				}
+			}
+			return "", ErrTokenRevoked
+		}
+
+		// Temporary error (network, OSM server issue, etc.)
+		slog.Error("tokenrefresh.failed",
+			"component", "tokenrefresh",
+			"event", "token.refresh_error",
+			"identifier", identifier,
+			"error", err,
+		)
+		return "", ErrTokenRefreshFailed
+	}
+
+	// Calculate expiry and call success callback
+	newExpiry := time.Now().Add(time.Duration(newTokens.ExpiresIn) * time.Second)
+	if onSuccess != nil {
+		if err := onSuccess(newTokens.AccessToken, newTokens.RefreshToken, newExpiry); err != nil {
+			slog.Error("tokenrefresh.success_callback_failed",
+				"component", "tokenrefresh",
+				"event", "token.update_error",
+				"identifier", identifier,
+				"error", err,
+			)
+			return "", ErrTokenRefreshFailed
+		}
+	}
+
+	slog.Info("tokenrefresh.success",
+		"component", "tokenrefresh",
+		"event", "token.refreshed",
+		"identifier", identifier,
+	)
+
+	return newTokens.AccessToken, nil
+}
+
+// Ensure Service implements osm.TokenRefresher
+var _ osm.TokenRefresher = (*Service)(nil)

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1,14 +1,23 @@
 package types
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 // ContextKey is a type for context keys to avoid collisions
 type ContextKey string
 
 // Context keys used across the application
 const (
-	UserContextKey ContextKey = "user"
+	UserContextKey         ContextKey = "user"
+	TokenRefreshFuncKey    ContextKey = "token_refresh_func"
 )
+
+// TokenRefreshFunc is a function that refreshes the current user's token.
+// It's bound with the appropriate callbacks at authentication time and stored in context.
+// Returns the new access token on success, or an error if refresh fails.
+type TokenRefreshFunc func(ctx context.Context) (newAccessToken string, err error)
 
 // User represents a user for the OSM API client.
 type User interface {


### PR DESCRIPTION
- Add ErrAccessRevoked sentinel error to oauthclient instead of string matching
- Create tokenrefresh.Service as central refresh handler with callback pattern
- TokenRefresher interface now takes callbacks for onSuccess/onRevoked
- deviceauth and webauth services provide storage-specific callbacks
- osm.Client uses context-bound TokenRefreshFunc for 401 retry
- Remove device-specific coupling from osm.Client (now stateless)
- Extract 401 retry logic into attemptTokenRefreshAndRetry method

The callback pattern allows type-specific storage operations (device codes vs web sessions) without the central refresh service knowing the details. Context-bound refresh functions are set by auth middleware, keeping business services unaware of refresh mechanics.

Fixes #13 